### PR TITLE
Fix missing dependencies in secure beacons

### DIFF
--- a/beacon/lib/secure/main.c
+++ b/beacon/lib/secure/main.c
@@ -17,7 +17,7 @@ NTSTATUS __stdcall _LdrLoadDll(PWSTR SearchPath OPTIONAL, PULONG DllCharacterist
 
     for (size_t i = 0; i < AllowDllCount; i++)
     {
-        if (strcmp(name, AllowDlls[i]) == 0)
+        if (_stricmp(name, AllowDlls[i]) == 0)
         {
             Allowed = TRUE;
 


### PR DESCRIPTION
In some cases the _LdrLoadDll function would be given DllName's with mixed cases
and or different casing than what was listed in the `AllowedDll` array in main.h.
This change changes the strcmp call to _stricmp to ignore differences in casing
while loading dlls. This shouldn't make a difference in terms of security since
windows file paths are case insensitive by default.

Closes #20