### PR TITLE
Make http server daemon thread to allow cleaner exit

### DIFF
--- a/lib/commands/exit.py
+++ b/lib/commands/exit.py
@@ -8,7 +8,6 @@ __description__ = "Exit shad0w C2"
 __author__ = "@_batsec_"
 
 def main(shad0w, args):
-
-    # yea ik
-    
-    os.kill(os.getpid(), signal.SIGTERM)
+    # Once we have logging we will probably want to make a more
+    # sophisticated exit routine
+    os.sys.exit(0)

--- a/shad0w.py
+++ b/shad0w.py
@@ -92,7 +92,7 @@ class Shad0wC2(object):
         # start the http server thread
         # self.debug.log("starting http server thread")
         thttp = Thread(target=http_server.run_serv, args=(self,))
-        thttp.daemon = False
+        thttp.daemon = True
         thttp.start()
         # asyncio.run(http_server.run_serv(self))
 


### PR DESCRIPTION
Currently the exit command kills the console thread however it doesn't
successfully kill the http server thread. The system ends up getting stuck
waiting for a lock and must be manually killed via SIGINT. This change
spawns the http server thread as a daemon thread so the whole program can
cleanly exit once there is only the daemon http thread left running.

References: https://docs.python.org/3/library/threading.html#thread-objects

Closes #39