### PR TITLE
docs: fix simple typo, reslove -> resolve

### DIFF
--- a/beacon/injectable/loader.c
+++ b/beacon/injectable/loader.c
@@ -392,7 +392,7 @@ BOOL InjectCode(CHAR* Bytes, SIZE_T Size, DWORD PID)
         ResumeThread(rThread);
     #endif
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯
@@ -458,7 +458,7 @@ BOOL InjectDLL(CHAR* Bytes, SIZE_T Size, DWORD PID)
     // start the thread executing again
     ResumeThread(rThread);
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯

--- a/beacon/reflection/loader.c
+++ b/beacon/reflection/loader.c
@@ -392,7 +392,7 @@ BOOL InjectCode(CHAR* Bytes, SIZE_T Size, DWORD PID)
         ResumeThread(rThread);
     #endif
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯
@@ -458,7 +458,7 @@ BOOL InjectDLL(CHAR* Bytes, SIZE_T Size, DWORD PID)
     // start the thread executing again
     ResumeThread(rThread);
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯

--- a/beacon/src/loader.c
+++ b/beacon/src/loader.c
@@ -394,7 +394,7 @@ BOOL InjectCode(CHAR* Bytes, SIZE_T Size, DWORD PID)
         ResumeThread(rThread);
     #endif
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯
@@ -542,7 +542,7 @@ BOOL InjectDLL(CHAR* Bytes, SIZE_T Size, DWORD PID)
         ResumeThread(rThread);
     #endif
 
-    // reslove the address of NtAlertResumeThread
+    // resolve the address of NtAlertResumeThread
     _NtAlertResumeThread NtAlertResumeThread = (_NtAlertResumeThread)GetProcAddress(LoadLibrary("ntdll.dll"), "NtAlertResumeThread");
 
     // honestly not sure why i need to do this, guess windows is just weird ¯\_(ツ)_/¯


### PR DESCRIPTION
There is a small typo in beacon/injectable/loader.c, beacon/reflection/loader.c, beacon/src/loader.c.

Should read `resolve` rather than `reslove`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md