### PR TITLE
Disabled dotnet telemetry & reorganized docker build layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM kalilinux/kali-rolling
  
 LABEL maintainer="batsec - @_batsec_"
 
-COPY . /root/shad0w
+# https://docs.microsoft.com/en-us/dotnet/core/tools/telemetry#how-to-opt-out
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1  
 
+# Install dependencies as a base container layer before copying full shad0w source
+COPY ./install.sh ./requirements.txt /root/shad0w/
 WORKDIR /root/shad0w
 RUN ./install.sh
+
+COPY . /root/shad0w
 
 ENTRYPOINT ["python3.8", "./shad0w.py"]


### PR DESCRIPTION
Separating the dockerfile  into two "copy" commands will prevent future builds from having to re-download all the requirements when only the shad0w source code has changed.