### PR TITLE
Fix dependencies for installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,7 @@ python3 -m pip install -r /root/shad0w/requirements.txt
 # install dotnet
 wget https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
 dpkg -i /tmp/packages-microsoft-prod.deb
+wget http://ftp.us.debian.org/debian/pool/main/i/icu/libicu57_57.1-6+deb9u4_amd64.deb -O /tmp/libicu57_57.1-6+deb9u4_amd64.deb
+dpkg -i /tmp/libicu57_57.1-6+deb9u4_amd64.deb
 apt update -y
 apt install dotnet-sdk-2.2 -y


### PR DESCRIPTION
The installer is failing due to the kali-rolling docker images missing the correct libicu version. This change pulls the missing libicu and install it, before trying to install dotnet-sdk-2.2