### PR TITLE
fixed possible writing wchar to char issue

### DIFF
--- a/beacon/lib/stdlib/getdir.c
+++ b/beacon/lib/stdlib/getdir.c
@@ -1,13 +1,9 @@
 #include <stdio.h>
 #include <windows.h>
 
-char* getdir()
-{
-    TCHAR NPath[MAX_PATH];
+char* getdir(){
+
     char* text = (char*)malloc(MAX_PATH + 1);
-    GetCurrentDirectory(MAX_PATH, NPath);
-
-    sprintf(text, "%s", NPath);
-
+    GetCurrentDirectoryA(MAX_PATH, text);
     return text;
 }


### PR DESCRIPTION
https://stackoverflow.com/questions/21223774/problems-with-wchar-t-sprintf
https://wiki.sei.cmu.edu/confluence/display/c/STR38-C.+Do+not+confuse+narrow+and+wide+character+strings+and+functions

Either use GetCurrentDirectoryA or  GetCurrentDirectoryW, i think the second one is more generic solution.
But  BeaconCallbackC2's  parameter is LPCSTR buffer, i changed to first one.