### PR TITLE
changed quotes to support mimikatz -x

### DIFF
--- a/lib/shellcode.py
+++ b/lib/shellcode.py
@@ -66,7 +66,7 @@ def generate(file, args, params, parse=True):
 
         # build the command line args if we need to
         if args.param:
-            cmdline += f" -p \'{params}\'"
+            cmdline += f" -p \"{params}\""
         if args.cls:
             cmdline += f" -c {args.cls}"
         if args.method:


### PR DESCRIPTION
-x in '   '  was giving invalid file error, while changing to "  " fix it.