### PR TITLE
register beacon modified

### DIFF
--- a/lib/path_handler.py
+++ b/lib/path_handler.py
@@ -52,7 +52,9 @@ class Handler(object):
             try:
                 # if the beacon isn't just checking in to give us
                 # data then build a response to give the beacon
-
+                if beacon_id not in self.shad0w.beacons.keys():
+                    return self.register_beacon(request)
+                
                 if ((opcode == 0) and (data == "")):
                     # get the current task
                     tasklist = self.shad0w.beacons[beacon_id]["task"]


### PR DESCRIPTION
Added support for register current beacon which has got beacon_id but if the server goes offline, the beacon is still online and server come back later,
It won't get any request on /register but on /path thus it won't register the current beacon.
Fixed that issue.